### PR TITLE
Fix OAuth2 settings not being saved - add proper sanitization

### DIFF
--- a/src/authorizer/class-options.php
+++ b/src/authorizer/class-options.php
@@ -1474,6 +1474,41 @@ class Options extends Singleton {
 			}
 		}
 
+		// Sanitize OAuth2 settings for all servers (1 through oauth2_num_servers).
+		$oauth2_num_servers = max( 1, min( 20, intval( $auth_settings['oauth2_num_servers'] ) ) );
+		foreach ( range( 1, $oauth2_num_servers ) as $oauth2_num_server ) {
+			$suffix = 1 === $oauth2_num_server ? '' : '_' . $oauth2_num_server;
+
+			// Sanitize Store OAuth2 access token (checkbox: value can only be '1' or empty string).
+			$auth_settings[ 'oauth2_store_access_token' . $suffix ] = array_key_exists( 'oauth2_store_access_token' . $suffix, $auth_settings ) && strlen( $auth_settings[ 'oauth2_store_access_token' . $suffix ] ) > 0 ? '1' : '';
+
+			// Sanitize Sync profile photo (checkbox: value can only be '1' or empty string).
+			$auth_settings[ 'oauth2_sync_profile_photo' . $suffix ] = array_key_exists( 'oauth2_sync_profile_photo' . $suffix, $auth_settings ) && strlen( $auth_settings[ 'oauth2_sync_profile_photo' . $suffix ] ) > 0 ? '1' : '';
+
+			// Sanitize Sync profile fields (checkbox: value can only be '1' or empty string).
+			$auth_settings[ 'oauth2_sync_profile_fields' . $suffix ] = array_key_exists( 'oauth2_sync_profile_fields' . $suffix, $auth_settings ) && strlen( $auth_settings[ 'oauth2_sync_profile_fields' . $suffix ] ) > 0 ? '1' : '';
+
+			// Sanitize Custom field mappings (textarea).
+			if ( array_key_exists( 'oauth2_custom_field_mappings' . $suffix, $auth_settings ) ) {
+				$auth_settings[ 'oauth2_custom_field_mappings' . $suffix ] = sanitize_textarea_field( $auth_settings[ 'oauth2_custom_field_mappings' . $suffix ] );
+			}
+
+			// Sanitize Default role (select: must be a valid WordPress role).
+			if ( array_key_exists( 'oauth2_default_role' . $suffix, $auth_settings ) ) {
+				$role = sanitize_text_field( $auth_settings[ 'oauth2_default_role' . $suffix ] );
+				// Verify role exists, otherwise use default.
+				if ( ! get_role( $role ) ) {
+					$role = get_option( 'default_role', 'subscriber' );
+				}
+				$auth_settings[ 'oauth2_default_role' . $suffix ] = $role;
+			}
+
+			// Sanitize Role mappings (textarea).
+			if ( array_key_exists( 'oauth2_role_mappings' . $suffix, $auth_settings ) ) {
+				$auth_settings[ 'oauth2_role_mappings' . $suffix ] = sanitize_textarea_field( $auth_settings[ 'oauth2_role_mappings' . $suffix ] );
+			}
+		}
+
 		// Make sure public pages is an empty array if it's empty.
 		// Note: this option doesn't exist in multisite options, so we first
 		// check to see if it exists.
@@ -1507,6 +1542,11 @@ class Options extends Singleton {
 		// Sanitize Sort users order (select: value can be 'asc', 'desc').
 		if ( ! isset( $auth_settings['advanced_users_sort_order'] ) || ! in_array( $auth_settings['advanced_users_sort_order'], array( 'asc', 'desc' ), true ) ) {
 			$auth_settings['advanced_users_sort_order'] = 'asc';
+		}
+
+		// Sanitize System log level (select: value can only be 'none', 'basic', 'detailed', or 'debug').
+		if ( ! isset( $auth_settings['system_log_level'] ) || ! in_array( $auth_settings['system_log_level'], array( 'none', 'basic', 'detailed', 'debug' ), true ) ) {
+			$auth_settings['system_log_level'] = 'basic';
 		}
 
 		// Sanitize Show Dashboard Widget (checkbox: value can only be '1' or empty string).


### PR DESCRIPTION
CRITICAL FIX: OAuth2 settings were not being saved because they were not included in the sanitize_options function.

Issues Fixed:
- "Store OAuth2 access token" checkbox not saving
- "Sync profile photo" checkbox not saving
- "Sync profile fields" checkbox not saving
- "Custom field mappings" textarea not saving
- "Default role for new users" dropdown not saving
- "Advanced role mappings" textarea not saving
- "System log level" dropdown not saving
- Save Changes button appearing to do nothing

Root Cause:
WordPress sanitize_options callback was not processing the new fields, so they were being silently discarded on save.

Changes Made:
- Added sanitization for all OAuth2 settings (servers 1-20)
- Added checkbox sanitization (oauth2_store_access_token, oauth2_sync_profile_photo, oauth2_sync_profile_fields)
- Added textarea sanitization (oauth2_custom_field_mappings, oauth2_role_mappings)
- Added role validation for oauth2_default_role (ensures role exists)
- Added system_log_level sanitization with allowed values
- Sanitization applied to all OAuth2 server instances (1-20)

Files Modified:
- class-options.php: Added OAuth2 settings sanitization in sanitize_options()

Testing:
- All OAuth2 settings now save correctly
- Invalid roles are rejected
- Textareas properly sanitized
- Checkboxes work as expected